### PR TITLE
When flipboard yaml option is "black" flip the board to show it in re…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -109,7 +109,7 @@ export default class ObsidianChess extends Plugin {
           line.trim().toLowerCase().startsWith("interactive:"),
         );
         const isFlippedBoardLine = lines.find((line) => {
-          line.trim().toLowerCase().startsWith("flipboard:")
+          return line.trim().toLowerCase().startsWith("flipboard:")
         })
 
         if (plyLine) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,13 +88,15 @@ export default class ObsidianChess extends Plugin {
       ctx: MarkdownPostProcessorContext,
     ) => {
       try {
-        this.setting.orientation = "white";
+        (this.setting as any).orientation = "white";
 
         // Extract parameters if present
         let ply: number | undefined = undefined;
         let showMove: ShowMoveOption = "none";
         let interactive = false;
         let pgnSource = source;
+        let isFlippedBoard = (this.setting as any).orientation === "black";
+
 
         const lines = source.split("\n");
         const plyLine = lines.find((line) =>
@@ -106,6 +108,9 @@ export default class ObsidianChess extends Plugin {
         const interactiveLine = lines.find((line) =>
           line.trim().toLowerCase().startsWith("interactive:"),
         );
+        const isFlippedBoardLine = lines.find((line) => {
+          line.trim().toLowerCase().startsWith("flipboard:")
+        })
 
         if (plyLine) {
           const plyMatch = plyLine.match(/ply:\s*(\d+)/i);
@@ -131,6 +136,20 @@ export default class ObsidianChess extends Plugin {
             interactive = interactiveMatch[1].toLowerCase() === "true";
           }
         }
+        if (isFlippedBoardLine) {
+          const isFlippedBoardMatch = isFlippedBoardLine.match(
+            /flipboard:\s*(true|false)/i,
+          );
+          if (isFlippedBoardMatch) {
+            isFlippedBoard = isFlippedBoardMatch[1].toLowerCase() === "true";
+          }
+          if (isFlippedBoard === true) {
+            this.setting.orientation = "black"
+          }
+          if (isFlippedBoard === false) {
+            this.setting.orientation = "white"
+          }
+        }
 
         // Remove parameter lines from the source
         pgnSource = lines
@@ -138,7 +157,8 @@ export default class ObsidianChess extends Plugin {
             (line) =>
               line !== plyLine &&
               line !== showMoveLine &&
-              line !== interactiveLine,
+              line !== interactiveLine &&
+              line !== isFlippedBoardLine,
           )
           .join("\n");
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,15 +88,13 @@ export default class ObsidianChess extends Plugin {
       ctx: MarkdownPostProcessorContext,
     ) => {
       try {
-        (this.setting as any).orientation = "white";
+        this.setting.orientation = "white";
 
         // Extract parameters if present
         let ply: number | undefined = undefined;
         let showMove: ShowMoveOption = "none";
         let interactive = false;
         let pgnSource = source;
-        let isFlippedBoard = (this.setting as any).orientation === "black";
-
 
         const lines = source.split("\n");
         const plyLine = lines.find((line) =>
@@ -108,9 +106,9 @@ export default class ObsidianChess extends Plugin {
         const interactiveLine = lines.find((line) =>
           line.trim().toLowerCase().startsWith("interactive:"),
         );
-        const isFlippedBoardLine = lines.find((line) => {
-          return line.trim().toLowerCase().startsWith("flipboard:")
-        })
+        const orientationLine = lines.find((line) =>
+          line.trim().toLowerCase().startsWith("orientation:"),
+        );
 
         if (plyLine) {
           const plyMatch = plyLine.match(/ply:\s*(\d+)/i);
@@ -136,18 +134,13 @@ export default class ObsidianChess extends Plugin {
             interactive = interactiveMatch[1].toLowerCase() === "true";
           }
         }
-        if (isFlippedBoardLine) {
-          const isFlippedBoardMatch = isFlippedBoardLine.match(
-            /flipboard:\s*(true|false)/i,
+        if (orientationLine) {
+          const orientationMatch = orientationLine.match(
+            /orientation:\s*(white|black)/i,
           );
-          if (isFlippedBoardMatch) {
-            isFlippedBoard = isFlippedBoardMatch[1].toLowerCase() === "true";
-          }
-          if (isFlippedBoard === true) {
-            this.setting.orientation = "black"
-          }
-          if (isFlippedBoard === false) {
-            this.setting.orientation = "white"
+          if (orientationMatch) {
+            this.setting.orientation =
+              orientationMatch[1].toLowerCase() as "white" | "black";
           }
         }
 
@@ -158,7 +151,7 @@ export default class ObsidianChess extends Plugin {
               line !== plyLine &&
               line !== showMoveLine &&
               line !== interactiveLine &&
-              line !== isFlippedBoardLine,
+              line !== orientationLine,
           )
           .join("\n");
 


### PR DESCRIPTION
A chess learner may want to see it from the perspective of the black especially on defense.
<img width="599" height="531" alt="Screenshot 2026-04-05 at 11 11 29 PM" src="https://github.com/user-attachments/assets/6cd5d965-c26b-482f-b248-c1d095446588" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `flipboard:` parameter in PGN notation to control chess board orientation between white and black perspectives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->