### PR TITLE
chore: add git, editor, and GitHub repo config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Double trailing spaces = hard linebreak in Markdown — do NOT strip
+trim_trailing_whitespace = false
+
+[*.{json,jsonc}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Normalize all text files to LF on commit
+* text=auto eol=lf
+
+# Explicitly text
+*.ts    text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.svg   text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+
+# Binary — never diff or convert
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## 📜 Summary
+
+Tick what applies (at least one), and *remove the other options*.
+
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Refactoring (non-functional, non-breaking change which improves design/maintainability/performance etc.)
+- [ ] Maintenance (non-functional, non-breaking change to upgrade dependencies, tooling etc.)
+- [ ] Documentation (any purely documentation changes)
+- [ ] Other: Describe
+
+Also write a brief summary of the change.
+
+## 🤨 Why
+
+- Describe the motivation for the PR in brief.  What problem does it solve? What benefits does it bring?
+- Include a reference (link to) to any relevant Github issue(s), if applicable.
+
+## 💡 What & How
+
+- Describe what work was done as briefly as possible but with sufficient detail to understand the changes.
+
+## 🧪 Testing & validation
+
+- List any tests added to cover the feature being implemented/bug being fixes.
+- Confirm the status of the test suite (should be 100% green) and  coverage statue, which should not have decreased.
+
+## 📸 Screenshots (if appropriate)
+
+- Add screenshots of the changes, if applicable, else remove this section.
+
+## 📝 Additional context
+
+- Add any other context here else remove this section.

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,9 @@ main.js
 pnpm-lock.yaml
 npm-lock.yaml
 
+# Test coverage
+coverage/
+
+# OS
 .DS_Store
+Thumbs.db


### PR DESCRIPTION
## 📜 Summary

- [x] Maintenance (non-functional, non-breaking change to upgrade dependencies, tooling etc.)

Adds standard repository hygiene files: line-ending normalization, gitignore improvements, EditorConfig, and a PR template.

## 🤨 Why

- The repo had no `.gitattributes` or `.editorconfig`, leaving EOL handling up to each contributor's editor — a common source of noisy diffs on Windows/Mac mixed teams.
- `.gitignore` useful to exclude stuff that should be excluded. 
- PR template helps with consistency

## 💡 What & How

- `.gitattributes` — enforces LF on all text files at commit time; marks binaries.
- `.gitignore` — adds `coverage/` and `Thumbs.db`.
- `.editorconfig` — LF, 2-space indent, final newline; carves out `*.md` to preserve double-trailing-space hard linebreaks.
- `.github/pull_request_template.md` — structured PR template (summary, why, what, testing, screenshots).

## 🧪 Testing & validation

Config-only changes; no code affected. 

## 📝 Additional context

First in a stack of three PRs. The subsequent PRs (agent config, test suite) build on this branch.