### PR TITLE
chore: add AGENTS.md and agent skills docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Double trailing spaces = hard linebreak in Markdown — do NOT strip
+trim_trailing_whitespace = false
+
+[*.{json,jsonc}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Normalize all text files to LF on commit
+* text=auto eol=lf
+
+# Explicitly text
+*.ts    text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.svg   text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+
+# Binary — never diff or convert
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## 📜 Summary
+
+Tick what applies (at least one), and *remove the other options*.
+
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Refactoring (non-functional, non-breaking change which improves design/maintainability/performance etc.)
+- [ ] Maintenance (non-functional, non-breaking change to upgrade dependencies, tooling etc.)
+- [ ] Documentation (any purely documentation changes)
+- [ ] Other: Describe
+
+Also write a brief summary of the change.
+
+## 🤨 Why
+
+- Describe the motivation for the PR in brief.  What problem does it solve? What benefits does it bring?
+- Include a reference (link to) to any relevant Github issue(s), if applicable.
+
+## 💡 What & How
+
+- Describe what work was done as briefly as possible but with sufficient detail to understand the changes.
+
+## 🧪 Testing & validation
+
+- List any tests added to cover the feature being implemented/bug being fixes.
+- Confirm the status of the test suite (should be 100% green) and  coverage statue, which should not have decreased.
+
+## 📸 Screenshots (if appropriate)
+
+- Add screenshots of the changes, if applicable, else remove this section.
+
+## 📝 Additional context
+
+- Add any other context here else remove this section.

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,9 @@ main.js
 pnpm-lock.yaml
 npm-lock.yaml
 
+# Test coverage
+coverage/
+
+# OS
 .DS_Store
+Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm install          # install dependencies
+npm run build        # production build -> main.js
+npm run dev          # watch mode (incremental builds)
+npm test             # run Vitest test suite
+npm run test:watch   # watch mode for tests
+npm run test:coverage # coverage report
+npx eslint src/      # lint TypeScript sources
+```
+
+Manual testing of Obsidian integration requires loading `main.js` as a local plugin.
+
+## Working rules
+
+### Output style
+Tokens are expensive. Be brief and to the point. Omit preamble, pleasantries, and summaries of what you just did. One sentence per update. Code speaks louder than prose.
+
+### TDD/BDD workflow
+Follow strict red-green-refactor:
+1. Write one failing test that describes the behavior (red).
+2. Write the minimum code to make it pass (green).
+3. Refactor only while green.
+
+No work may be declared complete unless:
+- Passing tests exist for the new behavior.
+- `npm test` passes with zero failures (full regression).
+- Any regressions introduced are fixed before declaring done.
+
+Tests must use public interfaces only. No testing implementation details or private methods.
+
+### Commits
+Use [Conventional Commits](https://www.conventionalcommits.org/) with semver semantics:
+- `feat:` — new feature (triggers minor bump)
+- `fix:` — bug fix (triggers patch bump)
+- `feat!:` / `fix!:` / `BREAKING CHANGE:` — breaking change (triggers major bump)
+- `chore:`, `refactor:`, `test:`, `docs:` — no release
+
+Do **not** add `Co-Authored-By:` lines to commits, PRs, or anywhere else.
+
+When creating PRs, always use the template in `.github/pull_request_template.md` — fill every section, remove optional sections that don't apply.
+
+### Markdown authoring
+Double trailing spaces (`  `) produce a hard linebreak in Markdown. When writing markdown that uses frontmatter-style blocks or bullet lists where each line must stay on its own line (i.e. must not reflow into the previous line), terminate each line with two spaces. Never rely on a blank line between items when a hard linebreak within a block is intended. `.editorconfig` preserves trailing whitespace in `.md` files for this reason.
+
+## Architecture
+
+Obsidian plugin that renders chess positions as inline SVGs inside Markdown preview. The bundled output is a single `main.js` (CJS, via Rollup) that Obsidian loads directly.
+
+### Entry point: `src/main.ts`
+
+`ObsidianChess` (extends `Plugin`) registers two Markdown code block processors:
+
+- **`chessboard`** — FEN-based static boards. Parsing delegated to `parseCodeBlock()` in `Annotations.ts`; rendering via `SVGChessboard.fromFEN()`.
+- **`chessboard-pgn`** — PGN-based boards. Options (`ply`, `show-move`, `interactive`, `move-list`, `orientation`) are parsed inline from the source lines before the PGN content. Routes to either `SVGChessboard.fromPGN()` (static) or `createInteractivePGNBoard()` (interactive).
+
+Settings (board colors, max width) are stored via Obsidian's `loadData/saveData` and exposed through a `PluginSettingTab`.
+
+### Core SVG layer: `src/chessboardsvg/`
+
+- **`Chessboard.ts`** — Thin façade over `chess.js`. Handles FEN loading (with optional strict-mode bypass for non-standard positions) and PGN loading with ply replay. Tracks `lastMovePlayed` for move highlighting.
+- **`index.ts` (`SVGChessboard`)** — Main rendering class. Constructs the full SVG from board squares, coordinate labels, pieces, and annotations (highlights, arrows, icons, shapes). All SVG nodes are created via `activeDocument.createElementNS` (Obsidian's DOM API). Piece SVGs are recolored at construction time via `Pieces.ts`.
+- **`InteractivePGN.ts`** — Stateful interactive board. `PGNGameState` manages ply navigation efficiently (forward via `chess.move()`, backward via `chess.undo()`). `createInteractivePGNBoard()` builds the DOM container with nav buttons, optional move-list panel, and keyboard arrow-key handlers.
+- **`Arrow.ts`**, **`Shapes.ts`**, **`Icons.ts`** — Pure SVG helpers for annotation rendering. Icons are SVG files imported as strings via `rollup-plugin-svg-import`.
+
+### Annotation parsing: `src/Annotations.ts`
+
+`parseCodeBlock()` splits the FEN code block into the FEN string plus `annotations:` lines. Each annotation token is parsed by prefix: `A` (arrow), `H` (highlight), `C`/`S`/`Q` (shapes), `!!`/`!?`/`!`/`??`/`?`/`F` (move-quality icons). Color modifiers `/r`, `/g`, `/b`, `/y` are suffix-matched.
+
+### Key constraints
+
+- The fixed SVG viewBox is `0 0 320 320` (8×8 grid of 40px squares). Board max-width is controlled via CSS custom property `--chess-board-max-width`.
+- `activeDocument` (not `document`) must be used for all DOM creation — this is Obsidian's multi-window API.
+- PGN annotations are not yet supported (static PGN path has a TODO stub in `main.ts`).
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`THeK3nger/obsidian-chessboard`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo — `CONTEXT.md` at root + `docs/adr/`. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── 0002-*.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## 📜 Summary

- [x] Maintenance (non-functional, non-breaking change to upgrade dependencies, tooling etc.)

Renames `CLAUDE.md` to `AGENTS.md` for cross-agent-harness interoperability, and adds `docs/agents/` configuration consumed by AI agent skills.

## 🤨 Why

- `CLAUDE.md` is only read by Claude Code; renaming to `AGENTS.md` allows other agent runtimes (OpenAI Agents, etc.) to discover the same guidance.
- The `docs/agents/` files configure agent skills for issue tracking, triage labels, and domain documentation layout — enabling automated triage, PR creation, and architecture review against this repo.

## 💡 What & How

- `AGENTS.md` — renamed from `CLAUDE.md`; all project guidance, working rules, architecture notes, and commit conventions live here.
- `CLAUDE.md` — reduced to a single `@AGENTS.md` reference so Claude Code still finds the content.
- `docs/agents/issue-tracker.md` — GitHub Issues via `gh` CLI.
- `docs/agents/triage-labels.md` — canonical five-role triage label mapping.
- `docs/agents/domain.md` — single-context layout rules for `CONTEXT.md` and `docs/adr/`.

## 🧪 Testing & validation

No code changes. Test suite passes with zero failures.

## 📝 Additional context

Second in a stack of three PRs; depends on #23.