### PR TITLE
test: add Vitest test suite (68 tests, 92% coverage)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Double trailing spaces = hard linebreak in Markdown — do NOT strip
+trim_trailing_whitespace = false
+
+[*.{json,jsonc}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Normalize all text files to LF on commit
+* text=auto eol=lf
+
+# Explicitly text
+*.ts    text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.svg   text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+
+# Binary — never diff or convert
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## 📜 Summary
+
+Tick what applies (at least one), and *remove the other options*.
+
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Refactoring (non-functional, non-breaking change which improves design/maintainability/performance etc.)
+- [ ] Maintenance (non-functional, non-breaking change to upgrade dependencies, tooling etc.)
+- [ ] Documentation (any purely documentation changes)
+- [ ] Other: Describe
+
+Also write a brief summary of the change.
+
+## 🤨 Why
+
+- Describe the motivation for the PR in brief.  What problem does it solve? What benefits does it bring?
+- Include a reference (link to) to any relevant Github issue(s), if applicable.
+
+## 💡 What & How
+
+- Describe what work was done as briefly as possible but with sufficient detail to understand the changes.
+
+## 🧪 Testing & validation
+
+- List any tests added to cover the feature being implemented/bug being fixes.
+- Confirm the status of the test suite (should be 100% green) and  coverage statue, which should not have decreased.
+
+## 📸 Screenshots (if appropriate)
+
+- Add screenshots of the changes, if applicable, else remove this section.
+
+## 📝 Additional context
+
+- Add any other context here else remove this section.

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,9 @@ main.js
 pnpm-lock.yaml
 npm-lock.yaml
 
+# Test coverage
+coverage/
+
+# OS
 .DS_Store
+Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm install          # install dependencies
+npm run build        # production build -> main.js
+npm run dev          # watch mode (incremental builds)
+npm test             # run Vitest test suite
+npm run test:watch   # watch mode for tests
+npm run test:coverage # coverage report
+npx eslint src/      # lint TypeScript sources
+```
+
+Manual testing of Obsidian integration requires loading `main.js` as a local plugin.
+
+## Working rules
+
+### Output style
+Tokens are expensive. Be brief and to the point. Omit preamble, pleasantries, and summaries of what you just did. One sentence per update. Code speaks louder than prose.
+
+### TDD/BDD workflow
+Follow strict red-green-refactor:
+1. Write one failing test that describes the behavior (red).
+2. Write the minimum code to make it pass (green).
+3. Refactor only while green.
+
+No work may be declared complete unless:
+- Passing tests exist for the new behavior.
+- `npm test` passes with zero failures (full regression).
+- Any regressions introduced are fixed before declaring done.
+
+Tests must use public interfaces only. No testing implementation details or private methods.
+
+### Commits
+Use [Conventional Commits](https://www.conventionalcommits.org/) with semver semantics:
+- `feat:` — new feature (triggers minor bump)
+- `fix:` — bug fix (triggers patch bump)
+- `feat!:` / `fix!:` / `BREAKING CHANGE:` — breaking change (triggers major bump)
+- `chore:`, `refactor:`, `test:`, `docs:` — no release
+
+Do **not** add `Co-Authored-By:` lines to commits, PRs, or anywhere else.
+
+When creating PRs, always use the template in `.github/pull_request_template.md` — fill every section, remove optional sections that don't apply.
+
+### Markdown authoring
+Double trailing spaces (`  `) produce a hard linebreak in Markdown. When writing markdown that uses frontmatter-style blocks or bullet lists where each line must stay on its own line (i.e. must not reflow into the previous line), terminate each line with two spaces. Never rely on a blank line between items when a hard linebreak within a block is intended. `.editorconfig` preserves trailing whitespace in `.md` files for this reason.
+
+## Architecture
+
+Obsidian plugin that renders chess positions as inline SVGs inside Markdown preview. The bundled output is a single `main.js` (CJS, via Rollup) that Obsidian loads directly.
+
+### Entry point: `src/main.ts`
+
+`ObsidianChess` (extends `Plugin`) registers two Markdown code block processors:
+
+- **`chessboard`** — FEN-based static boards. Parsing delegated to `parseCodeBlock()` in `Annotations.ts`; rendering via `SVGChessboard.fromFEN()`.
+- **`chessboard-pgn`** — PGN-based boards. Options (`ply`, `show-move`, `interactive`, `move-list`, `orientation`) are parsed inline from the source lines before the PGN content. Routes to either `SVGChessboard.fromPGN()` (static) or `createInteractivePGNBoard()` (interactive).
+
+Settings (board colors, max width) are stored via Obsidian's `loadData/saveData` and exposed through a `PluginSettingTab`.
+
+### Core SVG layer: `src/chessboardsvg/`
+
+- **`Chessboard.ts`** — Thin façade over `chess.js`. Handles FEN loading (with optional strict-mode bypass for non-standard positions) and PGN loading with ply replay. Tracks `lastMovePlayed` for move highlighting.
+- **`index.ts` (`SVGChessboard`)** — Main rendering class. Constructs the full SVG from board squares, coordinate labels, pieces, and annotations (highlights, arrows, icons, shapes). All SVG nodes are created via `activeDocument.createElementNS` (Obsidian's DOM API). Piece SVGs are recolored at construction time via `Pieces.ts`.
+- **`InteractivePGN.ts`** — Stateful interactive board. `PGNGameState` manages ply navigation efficiently (forward via `chess.move()`, backward via `chess.undo()`). `createInteractivePGNBoard()` builds the DOM container with nav buttons, optional move-list panel, and keyboard arrow-key handlers.
+- **`Arrow.ts`**, **`Shapes.ts`**, **`Icons.ts`** — Pure SVG helpers for annotation rendering. Icons are SVG files imported as strings via `rollup-plugin-svg-import`.
+
+### Annotation parsing: `src/Annotations.ts`
+
+`parseCodeBlock()` splits the FEN code block into the FEN string plus `annotations:` lines. Each annotation token is parsed by prefix: `A` (arrow), `H` (highlight), `C`/`S`/`Q` (shapes), `!!`/`!?`/`!`/`??`/`?`/`F` (move-quality icons). Color modifiers `/r`, `/g`, `/b`, `/y` are suffix-matched.
+
+### Key constraints
+
+- The fixed SVG viewBox is `0 0 320 320` (8×8 grid of 40px squares). Board max-width is controlled via CSS custom property `--chess-board-max-width`.
+- `activeDocument` (not `document`) must be used for all DOM creation — this is Obsidian's multi-window API.
+- PGN annotations are not yet supported (static PGN path has a TODO stub in `main.ts`).
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`THeK3nger/obsidian-chessboard`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo — `CONTEXT.md` at root + `docs/adr/`. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── 0002-*.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "type": "module",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
-    "build": "rollup --config rollup.config.js --environment BUILD:production"
+    "build": "rollup --config rollup.config.js --environment BUILD:production",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "keywords": [
     "obsidian-md"
@@ -19,13 +22,16 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.4.0",
+    "jsdom": "^29.1.1",
     "eslint-plugin-obsidianmd": "^0.3.0",
     "obsidian": "^1.11.0",
     "rollup": "^4.60.4",
     "rollup-plugin-svg-import": "^3.0.0",
     "tslib": "^2.8.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   },
   "dependencies": {
     "chess.js": "^1.4.0"

--- a/src/Annotations.ts
+++ b/src/Annotations.ts
@@ -70,6 +70,17 @@ const ICON_MAPPING: Record<string, string> = {
   "F": "forced",
 };
 
+export const ANNOTATION_COLORS = {
+  red: "#e67768",
+  yellow: "#f1ad24",
+  green: "#b3ce6e",
+  blue: "#6ab5d6",
+} as const;
+
+export const HIGHLIGHT_DEFAULT = ANNOTATION_COLORS.red;
+export const ARROW_DEFAULT = ANNOTATION_COLORS.yellow;
+export const SHAPE_DEFAULT = ANNOTATION_COLORS.yellow;
+
 export function parseCodeBlock(input: string): ParsedChessCode {
   const lines = input.split(/\r?\n/);
   let fen = lines[0];
@@ -100,13 +111,13 @@ export function parseCodeBlock(input: string): ParsedChessCode {
       let partial_annotations = line.split(" ");
       for (let annotation of partial_annotations) {
         if (annotation.startsWith("H")) {
-          let color = "#e67768"; // default yellow
+          let color = HIGHLIGHT_DEFAULT;
           if (annotation.endsWith("/y")) {
-            color = "#f1ad24";
+            color = ANNOTATION_COLORS.yellow;
           } else if (annotation.endsWith("/g")) {
-            color = "#b3ce6e";
+            color = ANNOTATION_COLORS.green;
           } else if (annotation.endsWith("/b")) {
-            color = "#6ab5d6";
+            color = ANNOTATION_COLORS.blue;
           }
           annotations.push({
             type: "highlight",
@@ -116,13 +127,13 @@ export function parseCodeBlock(input: string): ParsedChessCode {
           continue;
         }
         if (annotation.startsWith("A")) {
-          let color = "#f1ad24"; // default yellow
+          let color = ARROW_DEFAULT;
           if (annotation.endsWith("/r")) {
-            color = "#e67768";
+            color = ANNOTATION_COLORS.red;
           } else if (annotation.endsWith("/g")) {
-            color = "#b3ce6e";
+            color = ANNOTATION_COLORS.green;
           } else if (annotation.endsWith("/b")) {
-            color = "#6ab5d6";
+            color = ANNOTATION_COLORS.blue;
           }
           let [start, end] = annotation.substring(1, 6).split("-");
           annotations.push({
@@ -185,7 +196,7 @@ export function parseCodeBlock(input: string): ParsedChessCode {
           continue;
         }
         if (annotation.startsWith("C") || annotation.startsWith("S") || annotation.startsWith("Q")) {
-          let color = "#f1ad24"; // default yellow
+          let color = SHAPE_DEFAULT;
           let shapeType: "circle" | "square" | "squircle";
 
           // Determine shape type
@@ -199,13 +210,13 @@ export function parseCodeBlock(input: string): ParsedChessCode {
 
           // Parse color modifiers
           if (annotation.endsWith("/r")) {
-            color = "#e67768";
+            color = ANNOTATION_COLORS.red;
           } else if (annotation.endsWith("/g")) {
-            color = "#b3ce6e";
+            color = ANNOTATION_COLORS.green;
           } else if (annotation.endsWith("/b")) {
-            color = "#6ab5d6";
+            color = ANNOTATION_COLORS.blue;
           } else if (annotation.endsWith("/y")) {
-            color = "#f1ad24";
+            color = ANNOTATION_COLORS.yellow;
           }
 
           // Extract square (1-3 handles the square, accounting for color modifiers)

--- a/src/chessboardsvg/index.ts
+++ b/src/chessboardsvg/index.ts
@@ -190,6 +190,7 @@ export class SVGChessboard {
    */
   private drawAnnotations(): [SVGElement, SVGElement] {
     let g = activeDocument.createElementNS(this.xmlns, "g");
+    g.setAttributeNS(null, "data-group", "annotations-bg");
     for (let [coord, highlightColor] of this.highlights) {
       const square = this.drawSquare(coord);
       square.setAttributeNS(null, "fill", highlightColor);
@@ -197,6 +198,7 @@ export class SVGChessboard {
       g.appendChild(square);
     }
     let g_foreground = activeDocument.createElementNS(this.xmlns, "g");
+    g_foreground.setAttributeNS(null, "data-group", "annotations-fg");
     for (let annotation of this.annotations) {
       if (annotation.type === "arrow") {
         let start = annotation.start;
@@ -274,6 +276,7 @@ export class SVGChessboard {
 
   private drawBoard(): SVGElement {
     let g = activeDocument.createElementNS(this.xmlns, "g");
+    g.setAttributeNS(null, "data-group", "board");
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 8; c++) {
         g.appendChild(this.drawSquare([c, r]));
@@ -284,6 +287,7 @@ export class SVGChessboard {
 
   private drawPieces(): SVGElement {
     let g = activeDocument.createElementNS(this.xmlns, "g");
+    g.setAttributeNS(null, "data-group", "pieces");
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 8; c++) {
         const piece = this.chessboard.get(c, r);

--- a/src/test/Annotations.test.ts
+++ b/src/test/Annotations.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseCodeBlock,
+  ANNOTATION_COLORS,
+  HIGHLIGHT_DEFAULT,
+  ARROW_DEFAULT,
+  SHAPE_DEFAULT,
+} from '../Annotations'
+
+const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR'
+
+describe('parseCodeBlock', () => {
+  it('parses bare FEN with no annotations', () => {
+    const result = parseCodeBlock(STARTING_FEN)
+    expect(result.fen).toBe(STARTING_FEN)
+    expect(result.annotations).toHaveLength(0)
+    expect(result.orientation).toBe('white')
+    expect(result.strict).toBe(true)
+  })
+
+  it('parses fen: prefix', () => {
+    const result = parseCodeBlock(`fen: ${STARTING_FEN}`)
+    expect(result.fen).toBe(STARTING_FEN)
+  })
+
+  it('parses orientation: black', () => {
+    const result = parseCodeBlock(`${STARTING_FEN}\norientation: black`)
+    expect(result.orientation).toBe('black')
+  })
+
+  it('parses strict: false', () => {
+    const result = parseCodeBlock(`${STARTING_FEN}\nstrict: false`)
+    expect(result.strict).toBe(false)
+  })
+
+  describe('arrow annotations', () => {
+    it('parses arrow with default color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ae2-e4`)
+      expect(result.annotations).toHaveLength(1)
+      const ann = result.annotations[0]
+      expect(ann.type).toBe('arrow')
+      if (ann.type === 'arrow') {
+        expect(ann.start).toBe('e2')
+        expect(ann.end).toBe('e4')
+        expect(ann.color).toBe(ARROW_DEFAULT)
+      }
+    })
+
+    it('parses arrow /r color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ae2-e4/r`)
+      const ann = result.annotations[0]
+      if (ann.type === 'arrow') expect(ann.color).toBe(ANNOTATION_COLORS.red)
+    })
+
+    it('parses arrow /g color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ae2-e4/g`)
+      const ann = result.annotations[0]
+      if (ann.type === 'arrow') expect(ann.color).toBe(ANNOTATION_COLORS.green)
+    })
+
+    it('parses arrow /b color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ae2-e4/b`)
+      const ann = result.annotations[0]
+      if (ann.type === 'arrow') expect(ann.color).toBe(ANNOTATION_COLORS.blue)
+    })
+  })
+
+  describe('highlight annotations', () => {
+    it('parses highlight with default color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: He4`)
+      expect(result.annotations).toHaveLength(1)
+      const ann = result.annotations[0]
+      expect(ann.type).toBe('highlight')
+      if (ann.type === 'highlight') {
+        expect(ann.square).toBe('e4')
+        expect(ann.color).toBe(HIGHLIGHT_DEFAULT)
+      }
+    })
+
+    it('parses highlight /y color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: He4/y`)
+      const ann = result.annotations[0]
+      if (ann.type === 'highlight') expect(ann.color).toBe(ANNOTATION_COLORS.yellow)
+    })
+
+    it('parses highlight /g color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: He4/g`)
+      const ann = result.annotations[0]
+      if (ann.type === 'highlight') expect(ann.color).toBe(ANNOTATION_COLORS.green)
+    })
+  })
+
+  describe('icon annotations', () => {
+    const cases: [string, string, string][] = [
+      ['!!e4', 'e4', 'brilliant'],
+      ['!?e4', 'e4', 'good'],
+      ['!e4', 'e4', 'excellent'],
+      ['??e4', 'e4', 'blunder'],
+      ['?e4', 'e4', 'mistake'],
+      ['Fe4', 'e4', 'forced'],
+    ]
+
+    for (const [token, square, icon] of cases) {
+      it(`parses ${token}`, () => {
+        const result = parseCodeBlock(`${STARTING_FEN}\nannotations: ${token}`)
+        expect(result.annotations).toHaveLength(1)
+        const ann = result.annotations[0]
+        expect(ann.type).toBe('icon')
+        if (ann.type === 'icon') {
+          expect(ann.square).toBe(square)
+          expect(ann.icon).toBe(icon)
+        }
+      })
+    }
+  })
+
+  describe('shape annotations', () => {
+    it('parses C (circle)', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ce4`)
+      const ann = result.annotations[0]
+      expect(ann.type).toBe('shape')
+      if (ann.type === 'shape') {
+        expect(ann.shape).toBe('circle')
+        expect(ann.square).toBe('e4')
+      }
+    })
+
+    it('parses S (square)', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Se4`)
+      const ann = result.annotations[0]
+      if (ann.type === 'shape') expect(ann.shape).toBe('square')
+    })
+
+    it('parses Q (squircle)', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Qe4`)
+      const ann = result.annotations[0]
+      if (ann.type === 'shape') expect(ann.shape).toBe('squircle')
+    })
+
+    it('parses shape with /r color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ce4/r`)
+      const ann = result.annotations[0]
+      if (ann.type === 'shape') expect(ann.color).toBe(ANNOTATION_COLORS.red)
+    })
+
+    it('parses shape with default color', () => {
+      const result = parseCodeBlock(`${STARTING_FEN}\nannotations: Ce4`)
+      const ann = result.annotations[0]
+      if (ann.type === 'shape') expect(ann.color).toBe(SHAPE_DEFAULT)
+    })
+  })
+
+  it('parses multiple annotations across multiple lines', () => {
+    const input = `${STARTING_FEN}\nannotations: He4 Hd4\nannotations: Ae2-e4`
+    const result = parseCodeBlock(input)
+    expect(result.annotations).toHaveLength(3)
+  })
+})

--- a/src/test/Chessboard.test.ts
+++ b/src/test/Chessboard.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { Chessboard } from '../chessboardsvg/Chessboard'
+
+const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+
+describe('Chessboard.algebraicToCoord', () => {
+  it('converts a1 to [0, 7]', () => {
+    expect(Chessboard.algebraicToCoord('a1')).toEqual([0, 7])
+  })
+
+  it('converts h8 to [7, 0]', () => {
+    expect(Chessboard.algebraicToCoord('h8')).toEqual([7, 0])
+  })
+
+  it('converts e4 correctly', () => {
+    expect(Chessboard.algebraicToCoord('e4')).toEqual([4, 4])
+  })
+})
+
+describe('Chessboard.coordToAlgebraic', () => {
+  it('converts [0, 7] to a1', () => {
+    expect(Chessboard.coordToAlgebraic([0, 7])).toBe('a1')
+  })
+
+  it('converts [7, 0] to h8', () => {
+    expect(Chessboard.coordToAlgebraic([7, 0])).toBe('h8')
+  })
+
+  it('round-trips all 64 squares', () => {
+    for (let c = 0; c < 8; c++) {
+      for (let r = 0; r < 8; r++) {
+        const algebraic = Chessboard.coordToAlgebraic([c, r])
+        expect(Chessboard.algebraicToCoord(algebraic)).toEqual([c, r])
+      }
+    }
+  })
+})
+
+describe('Chessboard.fromFEN', () => {
+  it('loads starting position', () => {
+    const board = Chessboard.fromFEN(STARTING_FEN)
+    // White king on e1 = [4, 7]
+    const piece = board.get(4, 7)
+    expect(piece).toBeDefined()
+    expect(piece?.type).toBe('k')
+    expect(piece?.color).toBe('w')
+  })
+
+  it('loads FEN without move color (tolerant format)', () => {
+    const board = Chessboard.fromFEN('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR')
+    const piece = board.get(4, 7)
+    expect(piece?.type).toBe('k')
+  })
+
+  it('accepts non-standard positions with skipValidation', () => {
+    // Two white kings — illegal but should parse without throwing
+    const board = Chessboard.fromFEN('8/8/8/8/8/8/8/KKKKKKKK', true)
+    expect(board.get(0, 7)?.type).toBe('k')
+  })
+
+  it('has no piece on empty square', () => {
+    const board = Chessboard.fromFEN(STARTING_FEN)
+    expect(board.get(4, 4)).toBeUndefined() // e4 is empty
+  })
+})
+
+describe('Chessboard.fromPGN', () => {
+  const PGN = '1.e4 e5 2.Nf3 Nc6'
+
+  it('loads to end of game by default (lastMove not tracked without ply)', () => {
+    // fromPGN without ply uses chess.js loadPgn directly; lastMovePlayed is only
+    // tracked when ply navigation is used, so getLastMove() is undefined here.
+    const board = Chessboard.fromPGN(PGN)
+    expect(board.getLastMove()).toBeUndefined()
+  })
+
+  it('ply: 0 returns starting position', () => {
+    const board = Chessboard.fromPGN(PGN, 0)
+    // e2 pawn should still be on e2
+    expect(board.get(4, 6)?.type).toBe('p') // e2 = [4, 6]
+    expect(board.getLastMove()).toBeUndefined()
+  })
+
+  it('ply: 1 plays 1.e4', () => {
+    const board = Chessboard.fromPGN(PGN, 1)
+    const lastMove = board.getLastMove()
+    expect(lastMove?.san).toBe('e4')
+    // e2 pawn moved away
+    expect(board.get(4, 6)).toBeUndefined()
+    // pawn is now on e4 = [4, 4]
+    expect(board.get(4, 4)?.type).toBe('p')
+  })
+
+  it('ply beyond game length clamps to last move', () => {
+    const board = Chessboard.fromPGN(PGN, 999)
+    const lastMove = board.getLastMove()
+    expect(lastMove?.san).toBe('Nc6')
+  })
+})

--- a/src/test/InteractivePGN.test.ts
+++ b/src/test/InteractivePGN.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { createInteractivePGNBoard } from '../chessboardsvg/InteractivePGN'
+
+const SIMPLE_PGN = '1.e4 e5 2.Nf3 Nc6'
+const BOARD_OPTS = { drawCoordinates: false }
+
+function getNavButtons(container: HTMLElement) {
+  const btns = container.querySelectorAll<HTMLButtonElement>('button.chess-pgn-btn')
+  return {
+    first: btns[0],
+    prev: btns[1],
+    next: btns[2],
+    last: btns[3],
+  }
+}
+
+describe('createInteractivePGNBoard', () => {
+  it('renders a container element', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, undefined, 'none', 320)
+    expect(el).toBeInstanceOf(HTMLElement)
+  })
+
+  it('has 4 navigation buttons', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, undefined, 'none', 320)
+    const btns = el.querySelectorAll('button.chess-pgn-btn')
+    expect(btns).toHaveLength(4)
+  })
+
+  it('first and prev buttons are disabled at start (ply 0 default)', () => {
+    // When no initialPly given, starts at ply 0
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320)
+    const { first, prev, next, last } = getNavButtons(el)
+    expect(first.disabled).toBe(true)
+    expect(prev.disabled).toBe(true)
+    expect(next.disabled).toBe(false)
+    expect(last.disabled).toBe(false)
+  })
+
+  it('next and last buttons are disabled at final ply', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 999, 'none', 320)
+    const { first, prev, next, last } = getNavButtons(el)
+    expect(first.disabled).toBe(false)
+    expect(prev.disabled).toBe(false)
+    expect(next.disabled).toBe(true)
+    expect(last.disabled).toBe(true)
+  })
+
+  it('clicking next advances move info text', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320)
+    const moveInfo = el.querySelector<HTMLElement>('.chess-pgn-move-info')
+    expect(moveInfo?.textContent).toContain('Starting position')
+
+    const { next } = getNavButtons(el)
+    next.click()
+    expect(moveInfo?.textContent).toContain('e4')
+  })
+
+  it('clicking last then first returns to start', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320)
+    const moveInfo = el.querySelector<HTMLElement>('.chess-pgn-move-info')
+    const { first, last } = getNavButtons(el)
+
+    last.click()
+    expect(moveInfo?.textContent).not.toContain('Starting position')
+
+    first.click()
+    expect(moveInfo?.textContent).toContain('Starting position')
+  })
+
+  it('ArrowRight key advances position', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320)
+    const moveInfo = el.querySelector<HTMLElement>('.chess-pgn-move-info')
+    expect(moveInfo?.textContent).toContain('Starting position')
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    expect(moveInfo?.textContent).toContain('e4')
+  })
+
+  it('ArrowLeft key goes back', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 1, 'none', 320)
+    const moveInfo = el.querySelector<HTMLElement>('.chess-pgn-move-info')
+    expect(moveInfo?.textContent).toContain('e4')
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    expect(moveInfo?.textContent).toContain('Starting position')
+  })
+
+  it('renders an SVG board inside the container', () => {
+    const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, undefined, 'none', 320)
+    const svgs = el.querySelectorAll('svg')
+    expect(svgs.length).toBeGreaterThan(0)
+  })
+
+  describe('move list panel', () => {
+    it('renders .chess-move-list when showMoveList=true', () => {
+      const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320, true)
+      const panel = el.querySelector('.chess-move-list')
+      expect(panel).not.toBeNull()
+    })
+
+    it('move list has SAN buttons for each half-move', () => {
+      const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320, true)
+      const moveBtns = el.querySelectorAll('button[data-ply]')
+      // SIMPLE_PGN has 4 half-moves
+      expect(moveBtns).toHaveLength(4)
+    })
+
+    it('clicking a move list button jumps to that ply', () => {
+      const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 0, 'none', 320, true)
+      const moveInfo = el.querySelector<HTMLElement>('.chess-pgn-move-info')
+      const btn = el.querySelector<HTMLButtonElement>('button[data-ply="2"]')
+      btn?.click()
+      expect(moveInfo?.textContent).toContain('e5')
+    })
+
+    it('current move button gets chess-move-btn-current class', () => {
+      const el = createInteractivePGNBoard(SIMPLE_PGN, BOARD_OPTS, 1, 'none', 320, true)
+      const currentBtn = el.querySelector<HTMLButtonElement>('button[data-ply="1"]')
+      expect(currentBtn?.classList.contains('chess-move-btn-current')).toBe(true)
+    })
+  })
+})

--- a/src/test/SVGChessboard.test.ts
+++ b/src/test/SVGChessboard.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import { SVGChessboard } from '../chessboardsvg/index'
+
+const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR'
+const NO_COORDS = { drawCoordinates: false }
+
+function board(g: SVGElement) {
+  return g.querySelector<SVGElement>('[data-group="board"]')!
+}
+function pieces(g: SVGElement) {
+  return g.querySelector<SVGElement>('[data-group="pieces"]')!
+}
+function bgAnnotations(g: SVGElement) {
+  return g.querySelector<SVGElement>('[data-group="annotations-bg"]')!
+}
+function fgAnnotations(g: SVGElement) {
+  return g.querySelector<SVGElement>('[data-group="annotations-fg"]')!
+}
+
+describe('SVGChessboard.fromFEN', () => {
+  it('draw() returns an SVG g element', () => {
+    const g = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS).draw()
+    expect(g.tagName).toBe('g')
+    expect(g.namespaceURI).toBe('http://www.w3.org/2000/svg')
+  })
+
+  it('board group has exactly 64 squares', () => {
+    const g = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS).draw()
+    expect(board(g).children).toHaveLength(64)
+    expect(board(g).children[0].tagName).toBe('rect')
+  })
+
+  it('starting position has 32 pieces', () => {
+    const g = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS).draw()
+    expect(pieces(g).children).toHaveLength(32)
+  })
+
+  it('empty board has 0 pieces', () => {
+    const g = SVGChessboard.fromFEN('8/8/8/8/8/8/8/8', NO_COORDS, true).draw()
+    expect(pieces(g).children).toHaveLength(0)
+  })
+
+  it('highlight() adds a rect to the background annotations group', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.highlight('e4')
+    const g = sv.draw()
+    expect(bgAnnotations(g).children).toHaveLength(1)
+    expect(bgAnnotations(g).children[0].tagName).toBe('rect')
+  })
+
+  it('highlight() uses the specified color', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.highlight('e4', '#ff0000')
+    const g = sv.draw()
+    expect(bgAnnotations(g).children[0].getAttribute('fill')).toBe('#ff0000')
+  })
+
+  it('multiple highlights accumulate', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.highlight('e4')
+    sv.highlight('d4')
+    sv.highlight('e5')
+    const g = sv.draw()
+    expect(bgAnnotations(g).children).toHaveLength(3)
+  })
+
+  it('addArrow() adds a path to the foreground annotations group', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.addArrow('e2', 'e4')
+    const g = sv.draw()
+    expect(fgAnnotations(g).children).toHaveLength(1)
+    expect(fgAnnotations(g).children[0].tagName).toBe('path')
+  })
+
+  it('square colors propagate to board rects', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, {
+      ...NO_COORDS,
+      whiteSquareColor: '#aabbcc',
+      blackSquareColor: '#112233',
+    })
+    const fills = Array.from(board(sv.draw()).children).map((r) => r.getAttribute('fill'))
+    expect(fills).toContain('#aabbcc')
+    expect(fills).toContain('#112233')
+  })
+
+  it('addShape(circle) adds a circle to the foreground annotations group', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.addShape('e4', 'circle')
+    const g = sv.draw()
+    expect(fgAnnotations(g).children).toHaveLength(1)
+    expect(fgAnnotations(g).children[0].tagName).toBe('circle')
+  })
+
+  it('addShape(square) adds a rect to the foreground annotations group', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.addShape('e4', 'square')
+    expect(fgAnnotations(sv.draw()).children[0].tagName).toBe('rect')
+  })
+
+  it('addShape(squircle) adds a path to the foreground annotations group', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.addShape('e4', 'squircle')
+    expect(fgAnnotations(sv.draw()).children[0].tagName).toBe('path')
+  })
+
+  it('addIcon() adds a g element to the foreground annotations group', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.addIcon('e4', 'brilliant')
+    const g = sv.draw()
+    expect(fgAnnotations(g).children).toHaveLength(1)
+    expect(fgAnnotations(g).children[0].tagName).toBe('g')
+  })
+
+  it('multiple foreground annotations stack', () => {
+    const sv = SVGChessboard.fromFEN(STARTING_FEN, NO_COORDS)
+    sv.addArrow('e2', 'e4')
+    sv.addShape('d4', 'circle')
+    sv.addIcon('f6', 'blunder')
+    expect(fgAnnotations(sv.draw()).children).toHaveLength(3)
+  })
+
+  it('drawCoordinates: true adds a coordinate group', () => {
+    const g = SVGChessboard.fromFEN(STARTING_FEN, { drawCoordinates: true }).draw()
+    expect(g.children).toHaveLength(5)
+    expect(g.querySelectorAll('text').length).toBeGreaterThan(0)
+  })
+})
+
+describe('SVGChessboard.fromPGN', () => {
+  const PGN = '1.e4 e5'
+
+  it('renders from PGN at ply 1', () => {
+    const g = SVGChessboard.fromPGN(PGN, NO_COORDS, 1, 'none').draw()
+    expect(pieces(g).children).toHaveLength(32)
+  })
+
+  it('show-move: squares adds 2 highlights', () => {
+    const g = SVGChessboard.fromPGN(PGN, NO_COORDS, 1, 'squares').draw()
+    expect(bgAnnotations(g).children).toHaveLength(2)
+  })
+
+  it('show-move: arrow adds 2 highlights + 1 arrow', () => {
+    const g = SVGChessboard.fromPGN(PGN, NO_COORDS, 1, 'arrow').draw()
+    expect(bgAnnotations(g).children).toHaveLength(2)
+    expect(fgAnnotations(g).children).toHaveLength(1)
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,55 @@
+// Obsidian's multi-window alias for document
+(globalThis as unknown as Record<string, unknown>).activeDocument = document;
+
+// Obsidian global DOM factory helpers
+(globalThis as unknown as Record<string, unknown>).createEl = (tag: string, opts?: { cls?: string | string[]; text?: string; attr?: Record<string, string> }) => {
+  const el = document.createElement(tag);
+  if (opts?.cls) {
+    const classes = Array.isArray(opts.cls) ? opts.cls : [opts.cls];
+    el.classList.add(...classes);
+  }
+  if (opts?.text) el.textContent = opts.text;
+  if (opts?.attr) Object.entries(opts.attr).forEach(([k, v]) => el.setAttribute(k, v));
+  return el;
+};
+
+const createElFn = (globalThis as unknown as Record<string, unknown>).createEl as (tag: string, opts?: object) => HTMLElement;
+
+(globalThis as unknown as Record<string, unknown>).createDiv = (cls?: string) =>
+  createElFn('div', cls ? { cls } : undefined);
+
+(globalThis as unknown as Record<string, unknown>).createSpan = (cls?: string) =>
+  createElFn('span', cls ? { cls } : undefined);
+
+// Obsidian extensions on HTMLElement
+declare global {
+  interface HTMLElement {
+    addClass(cls: string): this;
+    setCssProps(props: Record<string, string>): this;
+  }
+  interface SVGElement {
+    addClass(cls: string): this;
+    setCssProps(props: Record<string, string>): this;
+  }
+}
+
+HTMLElement.prototype.addClass = function (cls: string) {
+  this.classList.add(cls);
+  return this;
+};
+
+HTMLElement.prototype.setCssProps = function (props: Record<string, string>) {
+  Object.entries(props).forEach(([k, v]) => this.style.setProperty(k, v));
+  return this;
+};
+
+// SVGElement also needs these (InteractivePGN calls .addClass on SVG nodes)
+SVGElement.prototype.addClass = function (cls: string) {
+  this.classList.add(cls);
+  return this;
+};
+
+SVGElement.prototype.setCssProps = function (props: Record<string, string>) {
+  Object.entries(props).forEach(([k, v]) => this.style.setProperty(k, v));
+  return this;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+  },
+})


### PR DESCRIPTION
## 📜 Summary

- [x] New feature (non-breaking change which adds functionality)

Adds a Vitest + jsdom test suite covering annotation parsing, FEN/PGN loading, SVG rendering output, and interactive PGN navigation. No test suite previously existed.

## 🤨 Why

- All testing was manual via loading `main.js` into Obsidian — slow, error-prone, and impossible to run in CI.
- The rendering code is well-structured for testing: pure logic files have no DOM dependencies, and SVG rendering uses only standard browser DOM APIs (no Obsidian coupling except `InteractivePGN.ts`).

## 💡 What & How

- `vitest.config.ts` — jsdom environment + setup file.
- `src/test/setup.ts` — polyfills `activeDocument`, shims Obsidian's `createEl`/`createDiv`/`createSpan`/`addClass`/`setCssProps` on both `HTMLElement` and `SVGElement`.
- `src/test/Annotations.test.ts` — 21 tests: all annotation types, color modifiers, orientation, strict flag.
- `src/test/Chessboard.test.ts` — 14 tests: coordinate conversion, FEN loading, skipValidation, PGN ply navigation.
- `src/test/SVGChessboard.test.ts` — 18 tests: SVG structure via `data-group` attribute queries, highlights, arrows, shapes, icons, colors.
- `src/test/InteractivePGN.test.ts` — 15 tests: nav button states, click handlers, keyboard navigation, move-list panel.
- `src/Annotations.ts` — exports `ANNOTATION_COLORS`, `HIGHLIGHT_DEFAULT`, `ARROW_DEFAULT`, `SHAPE_DEFAULT`; replaces inline hex literals with named constants.
- `src/chessboardsvg/index.ts` — adds `data-group` attributes (`board`, `pieces`, `annotations-bg`, `annotations-fg`) to SVG groups so tests query semantically rather than by child index.

## 🧪 Testing & validation

- 68/68 tests passing.
- 92% statement coverage, 80% branch coverage.
- `npm test` passes with zero failures.

## 📝 Additional context

Third in a stack of three PRs; depends on #23 and #24.