### PR TITLE
feat: add annotations support to chessboard-pgn blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New
+
+- Add `annotations:` support to `chessboard-pgn` blocks (arrows, highlights, icons, shapes), matching FEN mode. Annotations render at the target ply and hide when navigating away in interactive mode.
+
 ## v0.20.0
 
 ### New

--- a/README.md
+++ b/README.md
@@ -152,18 +152,21 @@ It is possible to specify a PGN diagram as interactive by using the `interactive
 
 You can also add `move-list: true` to show a move list next to the board (SAN in two columns, one full move per row). Click any half-move to jump there; the current position is highlighted. On small widths the list wraps below the board. If you set `move-list: true` without `interactive: true`, the plugin enables interactive mode for you so navigation and the list stay in sync.
 
+### Annotations in PGN Mode
+
+PGN diagrams support the same `annotations:` syntax as FEN boards (see [Annotations](#annotations-beta) above). Annotations are displayed only at the **target ply**: the value of `ply:` if specified, or the last move in the game if `ply:` is omitted. In interactive mode, annotations appear when the board is at the target ply and disappear when you navigate away.
+
+````
+```chessboard-pgn
+ply: 12
+annotations: Ac7-c5/r Hc7/g Hc5/g !c5 Ag7-g6
+1.d4 d5 2.Nc3 Nf6 3.Bf4 g6 4.e3 Bg7 5.Nf3 O-O 6.Be2 c5
+```
+````
+
 ### Current Limitations
 
-This supports the full PGN specification but, for now, the feature is experimental and has limitations:
-
-1. At the moment, this mode do not support annotations.
-
-Moreover, the syntax in PGN games is still unstable. I may change it in new versions.
-
-### Syntax
-
-- `A<square>-<square>`, draws an arrow from the first square to the second square. E.g., `Af8-b4`.
-- `H<square>`, highlight a specific square. E.g., `Hf8`.
+This supports the full PGN specification but, for now, the feature is experimental. The syntax in PGN games is still unstable and may change in new versions.
 
 ## How to compile the plugin
 

--- a/src/Annotations.ts
+++ b/src/Annotations.ts
@@ -72,6 +72,104 @@ const ICON_MAPPING: Record<string, string> = {
   "#B": "checkmate_black",
 };
 
+export const ANNOTATION_COLORS = {
+  red: "#e67768",
+  yellow: "#f1ad24",
+  green: "#b3ce6e",
+  blue: "#6ab5d6",
+} as const;
+
+export const HIGHLIGHT_DEFAULT = ANNOTATION_COLORS.red;
+export const ARROW_DEFAULT = ANNOTATION_COLORS.yellow;
+export const SHAPE_DEFAULT = ANNOTATION_COLORS.yellow;
+
+export function parseAnnotationLine(line: string): Array<Annotation> {
+  const annotations: Array<Annotation> = [];
+  const tokens = line.split(" ");
+  for (const annotation of tokens) {
+    if (annotation.startsWith("H")) {
+      let color = HIGHLIGHT_DEFAULT;
+      if (annotation.endsWith("/y")) {
+        color = ANNOTATION_COLORS.yellow;
+      } else if (annotation.endsWith("/g")) {
+        color = ANNOTATION_COLORS.green;
+      } else if (annotation.endsWith("/b")) {
+        color = ANNOTATION_COLORS.blue;
+      }
+      annotations.push({ type: "highlight", square: annotation.substring(1, 3), color });
+      continue;
+    }
+    if (annotation.startsWith("A")) {
+      let color = ARROW_DEFAULT;
+      if (annotation.endsWith("/r")) {
+        color = ANNOTATION_COLORS.red;
+      } else if (annotation.endsWith("/g")) {
+        color = ANNOTATION_COLORS.green;
+      } else if (annotation.endsWith("/b")) {
+        color = ANNOTATION_COLORS.blue;
+      }
+      const [start, end] = annotation.substring(1, 6).split("-");
+      annotations.push({ type: "arrow", start, end, color });
+      continue;
+    }
+    if (annotation.startsWith("F")) {
+      annotations.push({ type: "icon", square: annotation.substring(1, 3), icon: ICON_MAPPING["F"] });
+      continue;
+    }
+    if (annotation.startsWith("#W")) {
+      annotations.push({ type: "icon", square: annotation.substring(2, 4), icon: ICON_MAPPING["#W"] });
+      continue;
+    }
+    if (annotation.startsWith("#B")) {
+      annotations.push({ type: "icon", square: annotation.substring(2, 4), icon: ICON_MAPPING["#B"] });
+      continue;
+    }
+    if (annotation.startsWith("!?")) {
+      annotations.push({ type: "icon", square: annotation.substring(2, 4), icon: ICON_MAPPING["!?"] });
+      continue;
+    }
+    if (annotation.startsWith("!!")) {
+      annotations.push({ type: "icon", square: annotation.substring(2, 4), icon: ICON_MAPPING["!!"] });
+      continue;
+    }
+    if (annotation.startsWith("!")) {
+      annotations.push({ type: "icon", square: annotation.substring(1, 3), icon: ICON_MAPPING["!"] });
+      continue;
+    }
+    if (annotation.startsWith("??")) {
+      annotations.push({ type: "icon", square: annotation.substring(2, 4), icon: ICON_MAPPING["??"] });
+      continue;
+    }
+    if (annotation.startsWith("?")) {
+      annotations.push({ type: "icon", square: annotation.substring(1, 3), icon: ICON_MAPPING["?"] });
+      continue;
+    }
+    if (annotation.startsWith("C") || annotation.startsWith("S") || annotation.startsWith("Q")) {
+      let color = SHAPE_DEFAULT;
+      let shapeType: "circle" | "square" | "squircle";
+      if (annotation.startsWith("C")) {
+        shapeType = "circle";
+      } else if (annotation.startsWith("S")) {
+        shapeType = "square";
+      } else {
+        shapeType = "squircle";
+      }
+      if (annotation.endsWith("/r")) {
+        color = ANNOTATION_COLORS.red;
+      } else if (annotation.endsWith("/g")) {
+        color = ANNOTATION_COLORS.green;
+      } else if (annotation.endsWith("/b")) {
+        color = ANNOTATION_COLORS.blue;
+      } else if (annotation.endsWith("/y")) {
+        color = ANNOTATION_COLORS.yellow;
+      }
+      annotations.push({ type: "shape", square: annotation.substring(1, 3), shape: shapeType, color });
+      continue;
+    }
+  }
+  return annotations;
+}
+
 export function parseCodeBlock(input: string): ParsedChessCode {
   const lines = input.split(/\r?\n/);
   let fen = lines[0];
@@ -98,146 +196,8 @@ export function parseCodeBlock(input: string): ParsedChessCode {
       orientation = line;
     }
     if (line.startsWith("annotations: ")) {
-      line = line.replace("annotations: ", "");
-      let partial_annotations = line.split(" ");
-      for (let annotation of partial_annotations) {
-        if (annotation.startsWith("H")) {
-          let color = "#e67768"; // default yellow
-          if (annotation.endsWith("/y")) {
-            color = "#f1ad24";
-          } else if (annotation.endsWith("/g")) {
-            color = "#b3ce6e";
-          } else if (annotation.endsWith("/b")) {
-            color = "#6ab5d6";
-          }
-          annotations.push({
-            type: "highlight",
-            square: annotation.substring(1, 3),
-            color: color,
-          });
-          continue;
-        }
-        if (annotation.startsWith("A")) {
-          let color = "#f1ad24"; // default yellow
-          if (annotation.endsWith("/r")) {
-            color = "#e67768";
-          } else if (annotation.endsWith("/g")) {
-            color = "#b3ce6e";
-          } else if (annotation.endsWith("/b")) {
-            color = "#6ab5d6";
-          }
-          let [start, end] = annotation.substring(1, 6).split("-");
-          annotations.push({
-            type: "arrow",
-            start,
-            end,
-            color: color,
-          });
-          continue;
-        }
-        if (annotation.startsWith("F")) {
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(1, 3),
-            icon: ICON_MAPPING["F"],
-          });
-          continue;
-        }
-        if (annotation.startsWith("#W")) {
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(2, 4),
-            icon: ICON_MAPPING["#W"],
-          });
-          continue;
-        }
-        if (annotation.startsWith("#B")) {
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(2, 4),
-            icon: ICON_MAPPING["#B"],
-          });
-          continue;
-        }
-        if (annotation.startsWith("!?")) {
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(2, 4),
-            icon: ICON_MAPPING["!?"],
-          });
-          continue;
-        }
-        if (annotation.startsWith("!!")) {
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(2, 4),
-            icon: ICON_MAPPING["!!"],
-          });
-          continue;
-        }
-        if (annotation.startsWith("!")) {
-          let icon = ICON_MAPPING["!"];
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(1, 3),
-            icon: icon,
-          });
-          continue;
-        }
-        if (annotation.startsWith("??")) {
-          let icon = ICON_MAPPING["??"];
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(2, 4),
-            icon: icon,
-          });
-          continue;
-        }
-        if (annotation.startsWith("?")) {
-          let icon = ICON_MAPPING["?"];
-          annotations.push({
-            type: "icon",
-            square: annotation.substring(1, 3),
-            icon: icon,
-          });
-          continue;
-        }
-        if (annotation.startsWith("C") || annotation.startsWith("S") || annotation.startsWith("Q")) {
-          let color = "#f1ad24"; // default yellow
-          let shapeType: "circle" | "square" | "squircle";
-
-          // Determine shape type
-          if (annotation.startsWith("C")) {
-            shapeType = "circle";
-          } else if (annotation.startsWith("S")) {
-            shapeType = "square";
-          } else {
-            shapeType = "squircle";
-          }
-
-          // Parse color modifiers
-          if (annotation.endsWith("/r")) {
-            color = "#e67768";
-          } else if (annotation.endsWith("/g")) {
-            color = "#b3ce6e";
-          } else if (annotation.endsWith("/b")) {
-            color = "#6ab5d6";
-          } else if (annotation.endsWith("/y")) {
-            color = "#f1ad24";
-          }
-
-          // Extract square (1-3 handles the square, accounting for color modifiers)
-          const square = annotation.substring(1, 3);
-
-          annotations.push({
-            type: "shape",
-            square: square,
-            shape: shapeType,
-            color: color,
-          });
-          continue;
-        }
-      }
+      const tokenLine = line.replace("annotations: ", "");
+      annotations.push(...parseAnnotationLine(tokenLine));
     }
   }
   return { fen, annotations, orientation, strict };

--- a/src/PGNOptions.ts
+++ b/src/PGNOptions.ts
@@ -1,0 +1,73 @@
+import { Annotation, parseAnnotationLine } from "./Annotations";
+import { ShowMoveOption } from "./chessboardsvg/index";
+
+export interface ParsedPGNBlock {
+  pgnSource: string;
+  ply: number | undefined;
+  showMove: ShowMoveOption;
+  interactive: boolean;
+  moveList: boolean;
+  orientation: "white" | "black";
+  annotations: Annotation[];
+}
+
+export function parsePGNBlock(source: string): ParsedPGNBlock {
+  let ply: number | undefined = undefined;
+  let showMove: ShowMoveOption = "none";
+  let interactive = false;
+  let moveList = false;
+  let orientation: "white" | "black" = "white";
+  const annotations: Annotation[] = [];
+
+  const lines = source.split("\n");
+  const keepLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim().toLowerCase();
+
+    if (trimmed.startsWith("ply:")) {
+      const m = line.match(/ply:\s*(\d+)/i);
+      if (m) ply = parseInt(m[1], 10);
+      continue;
+    }
+    if (trimmed.startsWith("show-move:")) {
+      const m = line.match(/show-move:\s*(none|squares|arrow)/i);
+      if (m) showMove = m[1].toLowerCase() as ShowMoveOption;
+      continue;
+    }
+    if (trimmed.startsWith("interactive:")) {
+      const m = line.match(/interactive:\s*(true|false)/i);
+      if (m) interactive = m[1].toLowerCase() === "true";
+      continue;
+    }
+    if (trimmed.startsWith("move-list:")) {
+      const m = line.match(/move-list:\s*(true|false)/i);
+      if (m) moveList = m[1].toLowerCase() === "true";
+      continue;
+    }
+    if (trimmed.startsWith("orientation:")) {
+      const m = line.match(/orientation:\s*(white|black)/i);
+      if (m) orientation = m[1].toLowerCase() as "white" | "black";
+      continue;
+    }
+    if (trimmed.startsWith("annotations:")) {
+      const tokenLine = line.replace(/^annotations:\s*/i, "");
+      annotations.push(...parseAnnotationLine(tokenLine));
+      continue;
+    }
+
+    keepLines.push(line);
+  }
+
+  if (moveList && !interactive) interactive = true;
+
+  return {
+    pgnSource: keepLines.join("\n"),
+    ply,
+    showMove,
+    interactive,
+    moveList,
+    orientation,
+    annotations,
+  };
+}

--- a/src/chessboardsvg/InteractivePGN.ts
+++ b/src/chessboardsvg/InteractivePGN.ts
@@ -1,5 +1,6 @@
 import { Chess, Move } from "chess.js";
 import { SVGChessboard, SVGChessboardOptions, ShowMoveOption } from "./index";
+import { Annotation } from "../Annotations";
 
 /**
  * Manages the state of a PGN game for interactive navigation.
@@ -240,6 +241,8 @@ function renderBoard(
   gameState: PGNGameState,
   options: Partial<SVGChessboardOptions>,
   svgContainer: HTMLElement,
+  annotations: Annotation[],
+  targetPly: number,
 ): void {
   svgContainer.innerHTML = "";
 
@@ -263,6 +266,15 @@ function renderBoard(
     if (square) {
       const icon = checkmatedColor === "w" ? "checkmate_white" : "checkmate_black";
       svgBoard.addIcon(square, icon);
+    }
+  }
+
+  if (annotations.length > 0 && gameState.getCurrentPly() === targetPly) {
+    for (const ann of annotations) {
+      if (ann.type === "arrow") svgBoard.addArrow(ann.start, ann.end, ann.color);
+      else if (ann.type === "highlight") svgBoard.highlight(ann.square, ann.color);
+      else if (ann.type === "icon") svgBoard.addIcon(ann.square, ann.icon);
+      else if (ann.type === "shape") svgBoard.addShape(ann.square, ann.shape, ann.color);
     }
   }
 
@@ -385,9 +397,11 @@ export function createInteractivePGNBoard(
   showMove: ShowMoveOption,
   boardWidthPx: number,
   showMoveList = false,
+  annotations: Annotation[] = [],
 ): HTMLElement {
   // Create game state
   const gameState = new PGNGameState(pgnString, initialPly, showMove);
+  const targetPly = initialPly !== undefined ? gameState.getCurrentPly() : gameState.getTotalPlies();
 
   const container = createDiv("chess-pgn-container");
   container.setCssProps({ "--chess-board-max-width": `${boardWidthPx}px` });
@@ -405,7 +419,7 @@ export function createInteractivePGNBoard(
 
   // Update UI function
   const updateUI = () => {
-    renderBoard(gameState, options, boardContainer);
+    renderBoard(gameState, options, boardContainer, annotations, targetPly);
     updateMoveDisplay(gameState, moveInfo);
     updateButtonStates(gameState, {
       first: firstButton,

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,10 +10,10 @@ import {
 import {
   SVGChessboard,
   SVGChessboardOptions,
-  ShowMoveOption,
 } from "./chessboardsvg/index";
 import { parseCodeBlock } from "./Annotations";
 import { createInteractivePGNBoard } from "./chessboardsvg/InteractivePGN";
+import { parsePGNBlock } from "./PGNOptions";
 
 const DEFAULT_CHESS_SETTINGS = {
   whiteSquareColor: "#f0d9b5",
@@ -84,95 +84,11 @@ export default class ObsidianChess extends Plugin {
       ctx: MarkdownPostProcessorContext,
     ) => {
       try {
-        // Extract parameters if present
-        let ply: number | undefined = undefined;
-        let showMove: ShowMoveOption = "none";
-        let interactive = false;
-        let moveList = false;
-        let orientation: "white" | "black" = "white";
-        let pgnSource = source;
-
-        const lines = source.split("\n");
-        const plyLine = lines.find((line) =>
-          line.trim().toLowerCase().startsWith("ply:"),
-        );
-        const showMoveLine = lines.find((line) =>
-          line.trim().toLowerCase().startsWith("show-move:"),
-        );
-        const interactiveLine = lines.find((line) =>
-          line.trim().toLowerCase().startsWith("interactive:"),
-        );
-        const moveListLine = lines.find((line) =>
-          line.trim().toLowerCase().startsWith("move-list:"),
-        );
-        const orientationLine = lines.find((line) =>
-          line.trim().toLowerCase().startsWith("orientation:"),
-        );
-
-        if (plyLine) {
-          const plyMatch = plyLine.match(/ply:\s*(\d+)/i);
-          if (plyMatch) {
-            ply = parseInt(plyMatch[1], 10);
-          }
-        }
-
-        if (showMoveLine) {
-          const showMoveMatch = showMoveLine.match(
-            /show-move:\s*(none|squares|arrow)/i,
-          );
-          if (showMoveMatch) {
-            showMove = showMoveMatch[1].toLowerCase() as ShowMoveOption;
-          }
-        }
-
-        if (interactiveLine) {
-          const interactiveMatch = interactiveLine.match(
-            /interactive:\s*(true|false)/i,
-          );
-          if (interactiveMatch) {
-            interactive = interactiveMatch[1].toLowerCase() === "true";
-          }
-        }
-
-        if (moveListLine) {
-          const moveListMatch = moveListLine.match(
-            /move-list:\s*(true|false)/i,
-          );
-          if (moveListMatch) {
-            moveList = moveListMatch[1].toLowerCase() === "true";
-          }
-        }
-
-        if (moveList && !interactive) {
-          interactive = true;
-        }
-
-        if (orientationLine) {
-          const orientationMatch = orientationLine.match(
-            /orientation:\s*(white|black)/i,
-          );
-          if (orientationMatch) {
-            orientation = orientationMatch[1].toLowerCase() as
-              | "white"
-              | "black";
-          }
-        }
-
-        // Remove parameter lines from the source
-        pgnSource = lines
-          .filter(
-            (line) =>
-              line !== plyLine &&
-              line !== showMoveLine &&
-              line !== interactiveLine &&
-              line !== moveListLine &&
-              line !== orientationLine,
-          )
-          .join("\n");
+        const { pgnSource, ply, showMove, interactive, moveList, orientation, annotations } =
+          parsePGNBlock(source);
+        const boardOptions = { ...this.setting, orientation };
 
         if (interactive) {
-          const boardOptions = { ...this.setting, orientation };
-          // Use interactive rendering
           const interactiveBoard = createInteractivePGNBoard(
             pgnSource,
             boardOptions,
@@ -180,30 +96,17 @@ export default class ObsidianChess extends Plugin {
             showMove,
             this.setting.boardWidthPx,
             moveList,
+            annotations,
           );
           el.appendChild(interactiveBoard);
         } else {
-          const boardOptions = { ...this.setting, orientation };
-          // Use static rendering
-          const chessboard = SVGChessboard.fromPGN(
-            pgnSource,
-            boardOptions,
-            ply,
-            showMove,
-          );
-          // TODO: Add support for annotations in PGN
-          // for (let annotation of parsedCode.annotations) {
-          //   if (annotation.type === "arrow") {
-          //     chessboard.addArrow(
-          //       annotation.start,
-          //       annotation.end,
-          //       annotation.color
-          //     );
-          //   }
-          //   if (annotation.type === "highlight") {
-          //     chessboard.highlight(annotation.square, annotation.color);
-          //   }
-          // }
+          const chessboard = SVGChessboard.fromPGN(pgnSource, boardOptions, ply, showMove);
+          for (const ann of annotations) {
+            if (ann.type === "arrow") chessboard.addArrow(ann.start, ann.end, ann.color);
+            else if (ann.type === "highlight") chessboard.highlight(ann.square, ann.color);
+            else if (ann.type === "icon") chessboard.addIcon(ann.square, ann.icon);
+            else if (ann.type === "shape") chessboard.addShape(ann.square, ann.shape, ann.color);
+          }
           this.drawChessboard(chessboard, el, ctx);
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

- `chessboard-pgn` blocks now support the full `annotations:` syntax (arrows, highlights, icons, shapes), matching FEN mode
- Annotations render at the target ply and hide when navigating away in interactive mode

Example:
~~~~
```chessboard-pgn
ply: 12
show-move: arrows
annotations: !c5 Ag7-g6
interactive: true
1.d4 d5 2.Nc3 Nf6 3.Bf4 g6 4.e3 Bg7 5.Nf3 O-O 6. Be2 c5
```
~~~~

Render:
<img width="334" height="411" alt="image" src="https://github.com/user-attachments/assets/e7224066-aaaa-4827-a116-004f510d236b" />

## What changed

- Extract `parseAnnotationLine()` from `parseCodeBlock()` for reuse across block types
- New `parsePGNBlock()` in `src/PGNOptions.ts` replaces inline option parsing in `main.ts`
- `createInteractivePGNBoard` renders annotations at the target ply
- Static PGN path applies annotations after `SVGChessboard.fromPGN`
- Minimal README and CHANGELOG update

Reduced from the previous PR #29 per your feedback — this contains only the feature, no tooling, config, or tests (I would normally always include tests with a feature PR). 

The remaining changes from PR #29 are back on my fork as a series of stacked branches (build fixes, Vitest test suite, repo config, agent docs). Happy/eager to submit further PRs for any of those if you're interested.  I think the test coverage should be very valuable.  In the meantime I'm continuing to work on my tip branch where all the benefits (test coverage, etc.) are present.